### PR TITLE
introduce workspace/workspaceprocess package for explicitly starting workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
+data/workspace/go.sum
 dev

--- a/data/workspace/workspace.go
+++ b/data/workspace/workspace.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	_ "github.com/manifold/tractor/dev/workspace/delegates"
-
-	_ "github.com/manifold/tractor/pkg/workspace/init"
+	"github.com/manifold/tractor/pkg/workspace/workspaceprocess"
 )
 
-func main() {}
+func main() {
+	workspaceprocess.Run()
+}

--- a/pkg/workspace/workspaceprocess/workspaceprocess.go
+++ b/pkg/workspace/workspaceprocess/workspaceprocess.go
@@ -1,0 +1,87 @@
+package workspaceprocess
+
+import (
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/gliderlabs/com/objects"
+	"github.com/gliderlabs/stdcom/daemon"
+	"github.com/gliderlabs/stdcom/log/std"
+	"github.com/manifold/tractor/pkg/manifold"
+	frontend "github.com/manifold/tractor/pkg/session"
+	"github.com/manifold/tractor/pkg/workspace"
+
+	_ "github.com/manifold/tractor/com/file"
+	_ "github.com/manifold/tractor/com/http"
+	_ "github.com/manifold/tractor/com/net"
+)
+
+var (
+	addr  = flag.String("addr", "localhost:4243", "server listener address")
+	proto = flag.String("proto", "websocket", "server listener protocol")
+)
+
+func Run() {
+	flag.Parse()
+
+	var err error
+	manifold.Root, err = workspace.LoadHierarchy()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	registry := &objects.Registry{}
+
+	manifold.Walk(manifold.Root, func(n *manifold.Node) {
+		for _, com := range n.Components {
+			registry.Register(objects.New(com.Ref, ""))
+			if initializer, ok := com.Ref.(preInitializer); ok {
+				initializer.PreInitialize()
+			}
+		}
+	})
+
+	std.Register(registry)
+	registry.Reload()
+
+	manifold.Walk(manifold.Root, func(n *manifold.Node) {
+		for _, com := range n.Components {
+			if initializer, ok := com.Ref.(initializer); ok {
+				initializer.Initialize()
+			}
+		}
+	})
+
+	manifold.Root.Observe(&manifold.NodeObserver{
+		OnChange: func(node *manifold.Node, path string, old, new interface{}) {
+			if path == "Name" && node.Dir != "" {
+				newDir := filepath.Join(filepath.Dir(node.Dir), new.(string))
+				if node.Dir != newDir {
+					// TODO: do not break abstraction, have workspace handle this
+					if err := os.Rename(node.Dir, newDir); err != nil {
+						log.Fatal(err)
+					}
+				}
+			}
+			if err := workspace.SaveHierarchy(manifold.Root); err != nil {
+				log.Fatal(err)
+			}
+		},
+	})
+
+	go func() {
+		daemon.Run(registry, "app")
+	}()
+
+	frontend.ListenAndServe(manifold.Root, *proto, *addr)
+}
+
+type preInitializer interface {
+	PreInitialize()
+}
+
+type initializer interface {
+	Initialize()
+}


### PR DESCRIPTION
This is a copy of the `workspace/init` package that includes an explicit `Run()` func to start the server. This prevents a server from being started if something just imports the package. 

I'm not the best at picking package names, but I try to follow the [community conventions](https://blog.golang.org/package-names). I went with `workspace/workspaceprocess` for these reasons, but I'm happy to rename it.

1. Adding the `workspace` prefix to `workspaceprocess` hopefully makes it clear this is for running workspaces, and not doing anything with OS processes or whatever.
2. Keeping the `workspace/init` package intact allows existing workspaces to continue working. It's not difficult to update your personal one too (diff below).
3. Go doesn't like `init` package names. I guess calling something like `init.Run()` doesn't work, because `init` may reference `init()`.

This also gitignores `data/workspace/go.sum`. It'll be populated the first time a user runs their workspace.