### PR TITLE
fix Agent workspace start

### DIFF
--- a/cmd/tractor/agent.go
+++ b/cmd/tractor/agent.go
@@ -136,7 +136,7 @@ func runAgentCall(callmethod string) func(cmd *cobra.Command, args []string) {
 		wspath := args[0]
 		start := time.Now()
 		_, err := agentQRPCCall(os.Stdout, callmethod, wspath)
-		if err != nil {
+		if err != nil && err != io.EOF {
 			fmt.Printf("qrpc: %s [%s(%q) %s]\n", err, callmethod, wspath, time.Since(start))
 			os.Exit(1)
 			return
@@ -160,7 +160,7 @@ func agentQRPCCall(w io.Writer, cmd, wspath string) (string, error) {
 	}
 
 	if len(msg) > 0 {
-		fmt.Fprintf(w, "REPLY => %#v\n", msg)
+		fmt.Fprintf(w, "REPLY => %s\n", msg)
 	}
 
 	if resp.Hijacked {

--- a/cmd/tractor/agent.go
+++ b/cmd/tractor/agent.go
@@ -55,7 +55,7 @@ func openAgent() *agent.Agent {
 }
 
 func agentSockExists(ag *agent.Agent) bool {
-	_, err := os.Stat(ag.AgentSocket)
+	_, err := os.Stat(ag.SocketPath)
 	if err != nil {
 		return !os.IsNotExist(err)
 	}
@@ -147,7 +147,7 @@ func runAgentCall(callmethod string) func(cmd *cobra.Command, args []string) {
 
 func agentQRPCCall(w io.Writer, cmd, wspath string) (string, error) {
 	ag := openAgent()
-	sess, err := mux.DialUnix(ag.AgentSocket)
+	sess, err := mux.DialUnix(ag.SocketPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -58,6 +58,7 @@ func ListenAndServe(a *Agent) error {
 			r.Return(err)
 			return
 		}
+		r.Return(fmt.Sprintf("workspace %q started", ws.Name))
 	})
 
 	api.HandleFunc("stop", func(r qrpc.Responder, c *qrpc.Call) {

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -54,9 +54,7 @@ func ListenAndServe(a *Agent) error {
 		}
 
 		// TODO: shouldn't stream logs or block, but maybe we show a snippet? -JL
-
-		_, err = ws.Start()
-		if err != nil {
+		if err := ws.Start(); err != nil {
 			r.Return(err)
 			return
 		}

--- a/pkg/agent/workspace_test.go
+++ b/pkg/agent/workspace_test.go
@@ -20,15 +20,12 @@ func TestWorkspace(t *testing.T) {
 		require.NotNil(t, ws)
 		assert.Equal(t, int(StatusPartially), int(ws.Status))
 
-		ch := readWorkspace(t, ws.Start)
+		assert.Nil(t, ws.Start())
 		time.Sleep(time.Second)
 		assert.Equal(t, int(StatusAvailable), int(ws.Status))
 
 		ws.Stop()
 		assert.Equal(t, int(StatusPartially), int(ws.Status))
-
-		out := strings.TrimSpace(string(<-ch))
-		assert.True(t, strings.HasPrefix(out, "pid "))
 	})
 
 	t.Run("start/connect/stop", func(t *testing.T) {
@@ -36,7 +33,7 @@ func TestWorkspace(t *testing.T) {
 		require.NotNil(t, ws)
 		assert.Equal(t, int(StatusPartially), int(ws.Status))
 
-		startCh := readWorkspace(t, ws.Start)
+		assert.Nil(t, ws.Start())
 		time.Sleep(time.Second)
 		assert.Equal(t, int(StatusAvailable), int(ws.Status))
 
@@ -46,15 +43,11 @@ func TestWorkspace(t *testing.T) {
 		ws.Stop()
 		assert.Equal(t, int(StatusPartially), int(ws.Status))
 
-		startOut := strings.TrimSpace(string(<-startCh))
-		assert.True(t, strings.HasPrefix(startOut, "pid "))
-
 		connOut := strings.TrimSpace(string(<-connCh))
 		assert.True(t, strings.HasPrefix(connOut, "pid "))
-		assert.Equal(t, startOut, connOut)
 	})
 
-	t.Run("connect/start/stop", func(t *testing.T) {
+	t.Run("connect/stop", func(t *testing.T) {
 		ws := ag.Workspace("test3")
 		require.NotNil(t, ws)
 		assert.Equal(t, int(StatusPartially), int(ws.Status))
@@ -63,19 +56,11 @@ func TestWorkspace(t *testing.T) {
 		time.Sleep(time.Second)
 		assert.Equal(t, int(StatusAvailable), int(ws.Status))
 
-		startCh := readWorkspace(t, ws.Start)
-		time.Sleep(time.Second)
-		assert.Equal(t, int(StatusAvailable), int(ws.Status))
-
 		ws.Stop()
 		assert.Equal(t, int(StatusPartially), int(ws.Status))
 
-		startOut := strings.TrimSpace(string(<-startCh))
-		assert.True(t, strings.HasPrefix(startOut, "pid "))
-
 		connOut := strings.TrimSpace(string(<-connCh))
 		assert.True(t, strings.HasPrefix(connOut, "pid "))
-		assert.NotEqual(t, startOut, connOut)
 	})
 
 	t.Run("erroring workspace", func(t *testing.T) {
@@ -83,7 +68,7 @@ func TestWorkspace(t *testing.T) {
 		require.NotNil(t, ws)
 		assert.Equal(t, int(StatusPartially), int(ws.Status))
 
-		startCh := readWorkspace(t, ws.Start)
+		startCh := readWorkspace(t, ws.Connect)
 		time.Sleep(time.Second)
 		assert.Equal(t, int(StatusUnavailable), int(ws.Status))
 


### PR DESCRIPTION
`(*Workspace) Start()` was changed so it doesn't return the `io.ReadCloser` pipe. The qrpc server was also updated to return a message after `Start(). I think it was leaving the request open indefinitely since `Return()` was never called. Either that, or the discarded pipe reader from `Start()` was not being drained, and may have started blocking future writes.