### PR TITLE
Systray fixes

### DIFF
--- a/cmd/tractor/agent.go
+++ b/cmd/tractor/agent.go
@@ -41,10 +41,12 @@ func runAgent(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	stray := &systray.Service{Agent: ag}
 	dm := daemon.New(
 		&rpc.Service{Agent: ag},
-		&systray.Service{Agent: ag},
+		stray,
 	)
+	stray.SetDaemon(dm)
 	fatal(dm.Run(context.Background()))
 }
 

--- a/pkg/agent/rpc/service.go
+++ b/pkg/agent/rpc/service.go
@@ -42,7 +42,6 @@ func (s *Service) Serve(ctx context.Context) {
 	if err := server.Serve(s.l, s.api); err != nil {
 		fmt.Println(err)
 	}
-	os.Remove(s.Agent.SocketPath)
 }
 
 func (s *Service) TerminateDaemon() error {

--- a/pkg/agent/systray/service.go
+++ b/pkg/agent/systray/service.go
@@ -17,44 +17,46 @@ type Service struct {
 }
 
 func (s *Service) Serve(ctx context.Context) {
-	systray.Run(s.buildSystray(), func() {})
+	systray.Run(s.buildSystray, s.dm.Terminate)
+}
+
+func (s *Service) SetDaemon(dm *daemon.Daemon) {
+	s.dm = dm
 }
 
 func (s *Service) TerminateDaemon() error {
-	systray.Quit() // FIXME: THIS TERMINATES THE PROCESS
+	go func() { systray.Quit() }() // FIXME: THIS TERMINATES THE PROCESS
 	return nil
 }
 
-func (s *Service) buildSystray() func() {
-	return func() {
-		systray.SetIcon(icons.Tractor)
-		systray.SetTooltip("Tractor")
+func (s *Service) buildSystray() {
+	systray.SetIcon(icons.Tractor)
+	systray.SetTooltip("Tractor")
 
-		workspaces, err := s.Agent.Workspaces()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		for _, ws := range workspaces {
-			openItem := systray.AddMenuItem(ws.Name, "Open workspace")
-
-			ws.OnStatusChange(func(ws *agent.Workspace) {
-				openItem.SetIcon(ws.Status.Icon())
-			})
-
-			go func(mi *systray.MenuItem, ws *agent.Workspace) {
-				for {
-					<-openItem.ClickedCh
-					open.StartWith(ws.TargetPath, "Visual Studio Code.app")
-				}
-			}(openItem, ws)
-		}
-
-		systray.AddSeparator()
-		mQuitOrig := systray.AddMenuItem("Shutdown", "Quit and shutdown all workspaces")
-		go func(mi *systray.MenuItem) {
-			<-mi.ClickedCh
-			s.dm.Terminate()
-		}(mQuitOrig)
+	workspaces, err := s.Agent.Workspaces()
+	if err != nil {
+		log.Fatal(err)
 	}
+
+	for _, ws := range workspaces {
+		openItem := systray.AddMenuItem(ws.Name, "Open workspace")
+
+		ws.OnStatusChange(func(ws *agent.Workspace) {
+			openItem.SetIcon(ws.Status.Icon())
+		})
+
+		go func(mi *systray.MenuItem, ws *agent.Workspace) {
+			for {
+				<-openItem.ClickedCh
+				open.StartWith(ws.TargetPath, "Visual Studio Code.app")
+			}
+		}(openItem, ws)
+	}
+
+	systray.AddSeparator()
+	mQuitOrig := systray.AddMenuItem("Shutdown", "Quit and shutdown all workspaces")
+	go func(mi *systray.MenuItem) {
+		<-mi.ClickedCh
+		s.dm.Terminate()
+	}(mQuitOrig)
 }


### PR DESCRIPTION
This solves the issue of the system tray quitting before the rest of the daemon terminators run. It's a strange problem because the way `systray.Run()` works doesn't fit well into the daemon pattern.
Two main things were done to fix this:

1. `(*Daemon) Terminate()` is now the teardown func for `systray.Run()`. This will terminate the daemon.
2. `(*systray.Service) TerminateDaemon()` now calls `systray.Quit()` in a goroutine. Otherwise, this one terminator will block until all terminators have run, so it hangs forever. 

Here are some basic flows for when the agent daemon exits:

1. Closing agent by clicking Shutdown systray menu item.
  * `daemon.Run()` (runs all services, waits for `terminate()`)
    * [menu item callback](https://github.com/manifold/tractor/blob/291c2bba169ae54fb1b180c2812211e844fed8d7/pkg/agent/systray/service.go#L60)
    * `daemon.Terminate()`
    * Eventually... `go func() { systray.Quit() }()`
      * systray teardown Calls `daemon.Terminate()`, which returns early since `Terminate()` has started.
  * finish `daemon.Run()` (collect and return terminate errors)
2. Closing agent with SIGINTERRUPT
  * `daemon.Run()` (runs all services, waits for `terminate()`)
  * `TerminateOnSignal` notifies
  * `daemon.Terminate()`
    * Eventually... `go func() { systray.Quit() }()`
      * systray teardown Calls `daemon.Terminate()`, which returns early since `Terminate()` has started.
  * finish `daemon.Run()` (collect and return terminate errors)

TODO:

* Figure out how to run `systray.Run()` on the main os thread, always https://github.com/getlantern/systray/issues/20
* Make the `SetDaemon(*Daemon)` interface official and automatic? This lets the systray service call `(*Daemon) Terminate()` from the systray teardown, and from the menu item click handler.