### PR TITLE
Logging fixes

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/manifold/tractor/pkg/logging"
+	"github.com/manifold/tractor/pkg/logging/null"
 )
 
 // Agent manages multiple workspaces in a directory (default: ~/.tractor).
@@ -53,6 +54,7 @@ func Open(path string) (*Agent, error) {
 	a.SocketPath = filepath.Join(a.Path, "agent.sock")
 	a.WorkspacesPath = filepath.Join(a.Path, "workspaces")
 	a.WorkspaceSocketsPath = filepath.Join(a.Path, "sockets")
+	a.Logger = &null.Logger{}
 
 	os.MkdirAll(a.WorkspacesPath, 0700)
 	os.MkdirAll(a.WorkspaceSocketsPath, 0700)


### PR DESCRIPTION
This fixes an `agent` test failure because of a nil logger, and teaches the console package how to clean up its pipe readers.

I didn't go with the context from `Serve()` because the daemon is already waiting to call Terminate() when the context is done. Instead, I relied on [`pipewriter.Close()` behavior](https://golang.org/pkg/io/#PipeWriter.Close) where the reads start returning `io.EOF`, which breaks out of the `for` in `(*Console) LineReader()`.