### PR TITLE
inherit system environment for systray service subprocess

### DIFF
--- a/pkg/agent/systray/service.go
+++ b/pkg/agent/systray/service.go
@@ -43,7 +43,7 @@ func (s *Service) start() (err error) {
 	s.subcmd.Setup = func(cmd *exec.Cmd) error {
 
 		cmd.Stderr = os.Stderr
-		cmd.Env = []string{"SYSTRAY_SUBPROCESS=1"}
+		cmd.Env = append(os.Environ(), "SYSTRAY_SUBPROCESS=1")
 		if s.stdin, err = cmd.StdinPipe(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Tractor was failing on Ubuntu 18.04 graphical environment with:

```
Unable to init server: Could not connect: Connection refused

(tractor-agent:XXXXX): Gtk-WARNING **: cannot open display:
```

The environment variable `DISPLAY` was not being passed through to Tractor. This change inherits the entire environment (including `DISPLAY`) which allows GTK to connect to the display properly.