### PR TITLE
Makefile: teach 'clobber' to wipe out studio js files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ kill:
 clobber:
 	rm -rf local/bin/tractor
 	rm -rf local/bin/tractor-agent
+	rm -rf studio/plugins/*/lib
 
 versions:
 	@go version


### PR DESCRIPTION
Without removing the plugin lib directories, `make build` won't recompile. This fixes that. 