### PR TITLE
agent: read config from toml file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/manifold/tractor
 go 1.13
 
 require (
+	github.com/BurntSushi/toml v0.3.1
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/c-bata/go-prompt v0.2.3
 	github.com/containous/yaegi v0.7.4

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/alangpierce/go-forceexport v0.0.0-20160317203124-8f1d6941cd75/go.mod h1:uAXEEpARkRhCZfEvy/y0Jcc888f9tHCc1W7/UeEtreE=
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 h1:7Ip0wMmLHLRJdrloDxZfhMm0xrLXZS8+COSu2bXmEQs=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -22,8 +22,8 @@ import (
 
 // Agent manages multiple workspaces in a directory (default: ~/.tractor).
 type Agent struct {
-	Path                 string `toml:"-"` // ~/.tractor
-	ConfigPath           string `toml:"-"` // ~/.tractor/config.toml
+	Path                 string // ~/.tractor
+	ConfigPath           string // ~/.tractor/config.toml
 	SocketPath           string // ~/.tractor/agent.sock
 	WorkspacesPath       string // ~/.tractor/workspaces
 	WorkspaceSocketsPath string // ~/.tractor/sockets
@@ -32,11 +32,11 @@ type Agent struct {
 	PreferredBrowser     string
 	DevMode              bool
 
-	Daemon  *daemon.Daemon   `toml:"-"`
-	Console *console.Service `toml:"-"`
-	Logger  logging.Logger   `toml:"-"`
+	Daemon  *daemon.Daemon
+	Console *console.Service
+	Logger  logging.Logger
 
-	WorkspacesChanged chan struct{} `toml:"-"`
+	WorkspacesChanged chan struct{}
 	workspaces        map[string]*Workspace
 	mu                sync.RWMutex
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -12,9 +12,9 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/BurntSushi/toml"
 	"github.com/fsnotify/fsnotify"
 	"github.com/manifold/tractor/pkg/agent/console"
+	"github.com/manifold/tractor/pkg/config"
 	"github.com/manifold/tractor/pkg/misc/daemon"
 	"github.com/manifold/tractor/pkg/misc/logging"
 	"github.com/manifold/tractor/pkg/misc/logging/null"
@@ -76,10 +76,12 @@ func Open(path string, console *console.Service, devMode bool) (*Agent, error) {
 		a.Logger = &null.Logger{}
 	}
 
-	_, err = toml.DecodeFile(a.ConfigPath, &a)
-	if err != nil && !os.IsNotExist(err) {
+	cfg, err := config.ParseFile(a.ConfigPath)
+	if err != nil {
 		return nil, err
 	}
+
+	a.PreferredBrowser = cfg.Agent.PreferredBrowser
 
 	os.MkdirAll(a.WorkspacesPath, 0700)
 	os.MkdirAll(a.WorkspaceSocketsPath, 0700)

--- a/pkg/agent/systray/service.go
+++ b/pkg/agent/systray/service.go
@@ -113,7 +113,11 @@ func (s *Service) Serve(ctx context.Context) {
 				}
 				for _, ws := range workspaces {
 					if ws.Name == msg.Item.Title {
-						open.Start("http://localhost:3000/#" + ws.TargetPath)
+						if len(s.Agent.PreferredBrowser) > 0 {
+							open.StartWith("http://localhost:3000/#"+ws.TargetPath, s.Agent.PreferredBrowser)
+						} else {
+							open.Start("http://localhost:3000/#" + ws.TargetPath)
+						}
 					}
 				}
 			default:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+// ParseFile parses the given toml file into a Config.
+func ParseFile(path string) (Config, error) {
+	c := Config{}
+	_, err := toml.DecodeFile(path, &c)
+	if err != nil && !os.IsNotExist(err) {
+		return c, err
+	}
+	return c, nil
+}
+
+// Config describes the user settings from ~/.tractor/config.toml
+type Config struct {
+	Agent struct {
+		PreferredBrowser string
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,18 +7,25 @@ import (
 )
 
 // ParseFile parses the given toml file into a Config.
-func ParseFile(path string) (Config, error) {
-	c := Config{}
-	_, err := toml.DecodeFile(path, &c)
+func ParseFile(path string, cfg *Config) error {
+	_, err := toml.DecodeFile(path, cfg)
 	if err != nil && !os.IsNotExist(err) {
-		return c, err
+		return err
 	}
-	return c, nil
+	return nil
+}
+
+// Agent describes the user settings for the Tractor agent.
+type Agent struct {
+	SocketPath           string // ~/.tractor/agent.sock
+	WorkspacesPath       string // ~/.tractor/workspaces
+	WorkspaceSocketsPath string // ~/.tractor/sockets
+	WorkspaceBinPath     string // ~/.tractor/bin
+	GoBin                string
+	PreferredBrowser     string
 }
 
 // Config describes the user settings from ~/.tractor/config.toml
 type Config struct {
-	Agent struct {
-		PreferredBrowser string
-	}
+	Agent Agent
 }


### PR DESCRIPTION
Implements #65. As a side bonus, it's easy to tweak the other settings too if desired. Here's what my test file looked like:

```sh
$ cat ~/.tractor/config.toml
PreferredBrowser = "Google Chrome"
SocketPath = "/Users/rick/.tractor/tractor-custom.sock"
```

Some things to think about:

1. Is this fine on the Agent type? A case could be made to have some central tractor config type or package. If Agent is the main entry point, it may not be that necessary though.
2. Should the settings live under some `[[Agent]]` header?
3. Does this introduce any potential security issues? 

I believe I could add a new central config type, or start using toml `[[sections]]`, later without breaking backwards compatibility. So, I opted for the easiest solution: decoding with `*agent.Agent` directly, and not using any toml `[[sections]]`.

Also, I'm hoping https://github.com/skratchdot/open-golang/pull/27 gets merged. It'll at least clean up the change to `systray.Service`.

TODO:
* [ ] add tests!