### PR TITLE
Watcher interval config

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -77,6 +77,7 @@ func (a *Agent) InitializeDaemon() (err error) {
 	defer a.mu.Unlock()
 	for _, space := range spaces {
 		sup := supervisor.New(space.Path, space.Name, a.Console.NewPipe("@"+space.Name))
+		sup.WatchInterval = a.Config.DevWatchInterval()
 		a.workspaces = append(a.workspaces, &workspace.Entry{
 			Config:     space,
 			Supervisor: sup,
@@ -103,7 +104,9 @@ func (a *Agent) DaemonServices() []daemon.Service {
 	}
 	if a.DevMode {
 		services = append(services, []daemon.Service{
-			&selfdev.Service{},
+			&selfdev.Service{
+				Config: a.Config,
+			},
 		}...)
 	}
 	return services

--- a/pkg/agent/selfdev/service.go
+++ b/pkg/agent/selfdev/service.go
@@ -10,21 +10,20 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/manifold/tractor/pkg/agent/console"
+	"github.com/manifold/tractor/pkg/config"
 	"github.com/manifold/tractor/pkg/misc/daemon"
 	"github.com/manifold/tractor/pkg/misc/logging"
 	"github.com/manifold/tractor/pkg/misc/subcmd"
 	"github.com/radovskyb/watcher"
 )
 
-const WatchInterval = time.Millisecond * 50
-
 type Service struct {
 	Daemon  *daemon.Daemon
 	Logger  logging.Logger
 	Console *console.Service
+	Config  *config.Config
 
 	watcher *watcher.Watcher
 	output  io.WriteCloser
@@ -89,7 +88,7 @@ func (s *Service) TerminateDaemon() error {
 
 func (s *Service) Serve(ctx context.Context) {
 	go s.handleLoop(ctx)
-	if err := s.watcher.Start(WatchInterval); err != nil {
+	if err := s.watcher.Start(s.Config.DevWatchInterval()); err != nil {
 		logging.Error(s.Logger, err)
 	}
 }

--- a/pkg/workspace/editor/editor.go
+++ b/pkg/workspace/editor/editor.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Schobers/bindatafs"
+	"github.com/manifold/tractor/pkg/config"
 	"github.com/manifold/tractor/pkg/data/editors"
 	"github.com/manifold/tractor/pkg/misc/logging"
 	"github.com/progrium/hotweb/pkg/hotweb"
@@ -13,7 +14,8 @@ import (
 )
 
 type Service struct {
-	Log logging.Logger
+	Log    logging.Logger
+	Config *config.Config
 
 	hw *hotweb.Handler
 }
@@ -29,6 +31,7 @@ func (s *Service) InitializeDaemon() (err error) {
 		fs = afero.NewBasePathFs(afero.NewOsFs(), os.Getenv("TRACTOR_SRC"))
 	}
 	s.hw = hotweb.New(fs, "studio/editors", "/views")
+	s.hw.WatchInterval = s.Config.DevWatchInterval()
 	return nil
 }
 

--- a/pkg/workspace/supervisor/supervisor.go
+++ b/pkg/workspace/supervisor/supervisor.go
@@ -204,7 +204,7 @@ func (s *Supervisor) Serve(ctx context.Context) {
 }
 
 func (s *Supervisor) handleWatcher(ctx context.Context) {
-	debounce := debouncer.New(s.WatchInterval)
+	debounce := debouncer.New(WatchInterval)
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Tractor's file watching in dev mode is pretty CPU heavy (see #85). This adds a config option to tweak the interval. I tried to follow conventions where possible. The selfdev and editor services get a new `*config.Config` property. If they're ever initialized nil config, it'll still spit out the default. The workspace supervisor gets a new Interval property. 

This also bumps the default interval to 100ms to match hotweb's default. Though it's debatable if editor's hotweb watcher should even use the config value, since it's watching a much smaller subset of files.

EDIT: Forgot to mention that this only works on `tractor-agent`, since workspaces themselves have no tractor config. Maybe I can rip out the editor/hotweb stuff, since the config doesn't impact it anyway.

![](https://www.thewrap.com/wp-content/uploads/2017/09/rick-and-morty-ricks-ranked-cool-rick.jpg)
